### PR TITLE
Enable automatic level selection

### DIFF
--- a/src/adapters/hls.ts
+++ b/src/adapters/hls.ts
@@ -21,6 +21,7 @@ const LIVE_SYNC_DURATION_DELTA = 5;
 const DEFAULT_HLS_CONFIG: any = {
   abrEwmaDefaultEstimate: 5000 * 1000,
   liveSyncDuration: LIVE_SYNC_DURATION,
+  startLevel: -1,
 };
 const NETWORK_ERROR_RECOVER_TIMEOUT = 1000;
 const MEDIA_ERROR_RECOVER_TIMEOUT = 1000;


### PR DESCRIPTION
https://github.com/video-dev/hls.js/blob/master/docs/API.md#testbandwidth

> testBandwidth
> (default: true)
> 
> You must also set startLevel = -1 for this to have any impact. Otherwise, hls.js will load the first level in the manifest and start playback from there. If you do set startLevel = -1, a fragment of the lowest level will be downloaded to establish a bandwidth estimate before selecting the first auto-level. Disable this test if you'd like to provide your own estimate or use the default abrEwmaDefaultEstimate.