### PR TITLE
Feat: Update hls to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "classnames": "^2.2.6",
     "dashjs": "^3.2.0",
     "eventemitter3": "^4.0.7",
-    "hls.js": "^0.14.17",
+    "hls.js": "^1.4.12",
     "resize-observer-polyfill": "^1.5.0",
     "tslib": "^2.1.0"
   },
@@ -143,5 +143,6 @@
       "csscomb -tty-mode --",
       "git add"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/package.json
+++ b/package.json
@@ -143,6 +143,5 @@
       "csscomb -tty-mode --",
       "git add"
     ]
-  },
-  "packageManager": "yarn@1.22.19"
+  }
 }

--- a/src/adapters/hls.ts
+++ b/src/adapters/hls.ts
@@ -21,7 +21,7 @@ const LIVE_SYNC_DURATION_DELTA = 5;
 const DEFAULT_HLS_CONFIG: any = {
   abrEwmaDefaultEstimate: 5000 * 1000,
   liveSyncDuration: LIVE_SYNC_DURATION,
-  nudgeMaxRetry: 1000, // can be removed with hls v1.5.0 https://github.com/video-dev/hls.js/issues/5904#issuecomment-1762365377
+  nudgeMaxRetry: 40, // can be removed with hls v1.5.0 https://github.com/video-dev/hls.js/issues/5904#issuecomment-1762365377
 };
 const NETWORK_ERROR_RECOVER_TIMEOUT = 1000;
 const MEDIA_ERROR_RECOVER_TIMEOUT = 1000;

--- a/src/adapters/hls.ts
+++ b/src/adapters/hls.ts
@@ -21,6 +21,7 @@ const LIVE_SYNC_DURATION_DELTA = 5;
 const DEFAULT_HLS_CONFIG: any = {
   abrEwmaDefaultEstimate: 5000 * 1000,
   liveSyncDuration: LIVE_SYNC_DURATION,
+  nudgeMaxRetry: 1000, // can be removed with hls v1.5.0 https://github.com/video-dev/hls.js/issues/5904#issuecomment-1762365377
 };
 const NETWORK_ERROR_RECOVER_TIMEOUT = 1000;
 const MEDIA_ERROR_RECOVER_TIMEOUT = 1000;
@@ -183,10 +184,6 @@ export default class HlsAdapter implements IPlaybackAdapter {
   private _broadcastError(_error: any, data: any) {
     // TODO: Investigate why this callback is called after hls is destroyed
     if (!this.hls) {
-      return;
-    }
-    // TODO: `_error` argument is unused
-    if (!data.fatal) {
       return;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6612,7 +6612,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-eventemitter3@^4.0.0, eventemitter3@^4.0.3, eventemitter3@^4.0.7:
+eventemitter3@^4.0.0, eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -8210,13 +8210,10 @@ hipchat-notifier@^1.1.0:
     lodash "^4.0.0"
     request "^2.0.0"
 
-hls.js@^0.14.17:
-  version "0.14.17"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.14.17.tgz#0127cff2ec2f994a54eb955fe669ef6153a8e317"
-  integrity sha512-25A7+m6qqp6UVkuzUQ//VVh2EEOPYlOBg32ypr34bcPO7liBMOkKFvbjbCBfiPAOTA/7BSx1Dujft3Th57WyFg==
-  dependencies:
-    eventemitter3 "^4.0.3"
-    url-toolkit "^2.1.6"
+hls.js@^1.4.12:
+  version "1.4.12"
+  resolved "https://registry.npmjs.org/hls.js/-/hls.js-1.4.12.tgz#2022daa29d10c662387d80a5297f8330f8ef5ee2"
+  integrity sha512-1RBpx2VihibzE3WE9kGoVCtrhhDWTzydzElk/kyRbEOLnb1WIE+3ZabM/L8BqKFTCL3pUy4QzhXgD1Q6Igr1JA==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -16237,11 +16234,6 @@ url-parse@~1.4.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-url-toolkit@^2.1.6:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.2.3.tgz#78fa901215abbac34182066932220279b804522b"
-  integrity sha512-Da75SQoxsZ+2wXS56CZBrj2nukQ4nlGUZUP/dqUBG5E1su5GKThgT94Q00x81eVII7AyS1Pn+CtTTZ4Z0pLUtQ==
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
* Update hlsjs to latest v1.4.12
* Extend error events to be reported for non-fatal as well
* Update nudgeMaxRetry to big number to prevent media-error bufferStalledError that should be fixed in hlsjs v1.5.0 