### PR TITLE
fix: recover breaking playback on bufferFullError

### DIFF
--- a/src/adapters/hls.ts
+++ b/src/adapters/hls.ts
@@ -221,12 +221,15 @@ export default class HlsAdapter implements IPlaybackAdapter {
           this._logError(PlayableError.UNKNOWN, data);
           break;
       }
-      this._tryRecoverNetworkError();
+      if (data.fatal) {
+        this._tryRecoverNetworkError();
+      }
     } else if (data.type === ErrorTypes.MEDIA_ERROR) {
       // NOTE: when error is BUFFER_STALLED_ERROR or BUFFER_FULL_ERROR
       // video play successfully without recovering
       // while recover breaks video playback
       if (
+        data.fatal &&
         data.details !== ErrorDetails.BUFFER_STALLED_ERROR &&
         data.details !== ErrorDetails.BUFFER_FULL_ERROR
       ) {

--- a/src/adapters/hls.ts
+++ b/src/adapters/hls.ts
@@ -1,5 +1,4 @@
-import HlsJs from 'hls.js/dist/hls.light';
-
+import HlsJs from 'hls.js/dist/hls.light.js';
 import {
   geOverallBufferLength,
   getNearestBufferSegmentInfo,
@@ -224,10 +223,13 @@ export default class HlsAdapter implements IPlaybackAdapter {
       }
       this._tryRecoverNetworkError();
     } else if (data.type === ErrorTypes.MEDIA_ERROR) {
-      // NOTE: when error is BUFFER_STALLED_ERROR
+      // NOTE: when error is BUFFER_STALLED_ERROR or BUFFER_FULL_ERROR
       // video play successfully without recovering
       // while recover breaks video playback
-      if (data.details !== ErrorDetails.BUFFER_STALLED_ERROR) {
+      if (
+        data.details !== ErrorDetails.BUFFER_STALLED_ERROR &&
+        data.details !== ErrorDetails.BUFFER_FULL_ERROR
+      ) {
         this._tryRecoverMediaError();
       }
 

--- a/src/adapters/hls.ts
+++ b/src/adapters/hls.ts
@@ -225,14 +225,10 @@ export default class HlsAdapter implements IPlaybackAdapter {
         this._tryRecoverNetworkError();
       }
     } else if (data.type === ErrorTypes.MEDIA_ERROR) {
-      // NOTE: when error is BUFFER_STALLED_ERROR or BUFFER_FULL_ERROR
+      // NOTE: when error is BUFFER_STALLED_ERROR
       // video play successfully without recovering
       // while recover breaks video playback
-      if (
-        data.fatal &&
-        data.details !== ErrorDetails.BUFFER_STALLED_ERROR &&
-        data.details !== ErrorDetails.BUFFER_FULL_ERROR
-      ) {
+      if (data.fatal && data.details !== ErrorDetails.BUFFER_STALLED_ERROR) {
         this._tryRecoverMediaError();
       }
 


### PR DESCRIPTION
Retry leads to broken playback.
![image](https://github.com/wix-incubator/playable/assets/6772313/37538fdc-9b20-4f1b-a680-eed32827159f)
